### PR TITLE
Copy and navigate directly to job url

### DIFF
--- a/wwflow_extension/chrome/js/waterlooworks/constants.js
+++ b/wwflow_extension/chrome/js/waterlooworks/constants.js
@@ -1,2 +1,6 @@
 const postings = "https://waterlooworks.uwaterloo.ca/myAccount/co-op/coop-postings.htm"
 const dashboard = "https://waterlooworks.uwaterloo.ca/myAccount/dashboard.htm"
+
+const queryParamJobId = "ck_jobid"
+const queryParamCommand = "ck_cmd"
+const queryParamRedirect = "ck_redirect"

--- a/wwflow_extension/chrome/js/waterlooworks/job_nav.js
+++ b/wwflow_extension/chrome/js/waterlooworks/job_nav.js
@@ -1,0 +1,35 @@
+
+const urlSearchParams = new URLSearchParams(window.location.search);
+const params = Object.fromEntries(urlSearchParams.entries());
+
+if (params[queryParamJobId] !== undefined && params[queryParamRedirect] === "coop" && window.location.href.split('?')[0] !== postings) {
+    // replace old url in history
+    window.location.replace(postings + "?" + urlSearchParams.toString());
+} else if (params[queryParamJobId] !== undefined) {
+    const jobIdField = document.querySelector('form#searchByPostingNumberForm input#postingId');
+    if (jobIdField) { // on coop postings home, redirect
+        // jquery .val() doesn't work, use vanilla js .value
+        document.querySelector('form#searchByPostingNumberForm input#postingId').value = params[queryParamJobId];
+
+        // consume job id field so that we don't get stuck in redirect loop
+        delete params[queryParamJobId];
+        const urlSearchParamsUpdated = new URLSearchParams(params);
+
+        // submit form to redirect
+        $('form#searchByPostingNumberForm').prop("action", postings + "?" + urlSearchParamsUpdated.toString());
+        $('form#searchByPostingNumberForm').submit();
+    }
+} else { // might be on job specific page
+    const jobNameElement = $('h1.dashboard-header__profile-information-name');
+    if (jobNameElement.length > 0) {
+        const jobId = jobNameElement.text().split("-")[0].trim();
+        if (!isNaN(jobId)) { // successfully got jobid, on job specific page
+            params[queryParamJobId] = jobId;
+            const urlSearchParamsUpdated = new URLSearchParams(params);
+
+            history.replaceState({}, '', postings + "?" + urlSearchParamsUpdated.toString());
+        }
+    }
+}
+
+

--- a/wwflow_extension/chrome/manifest.json
+++ b/wwflow_extension/chrome/manifest.json
@@ -37,7 +37,8 @@
                 "js/waterlooworks/runner.js",
                 "js/waterlooworks/scraper.js",
                 "js/waterlooworks/constants.js",
-                "js/waterlooworks/data_reader.js"
+                "js/waterlooworks/data_reader.js",
+                "js/waterlooworks/job_nav.js"
             ],
             "css": [
                 "css/ww_styles.css",


### PR DESCRIPTION
Closes https://github.com/WilliamLQin/ColonelKernel/issues/40

We can just put an "open" button on the frontend for people to use to apply for now

I think shortlist to waterlooworks is possible by
1) open waterlooworks.uwaterloo.ca page (we **have** to be on waterlooworks.uwaterloo.ca to make any requests)
2) use this pr to navigate directly to job url
3) click on shortlist button
4) close the page

but I think it's usually kinda sketchy when things open up a webpage and immediately close it

A better solution would be to have a client shortlist that they make on our website, and then add a button to our WW extension dashboard that syncs the two shortlists (or _maybe_ we could auto-sync).