### PR TITLE
Remove Navbar Hover

### DIFF
--- a/client/src/components/NavigationBar/NavigationBar.tsx
+++ b/client/src/components/NavigationBar/NavigationBar.tsx
@@ -59,7 +59,7 @@ export const NavigationBar = (props: INavigationBar) => {
 
   return (
     <>
-      <AppBar position="static" sx={{ bgcolor: backgroundColor }}>
+      <AppBar position="static" elevation={0} sx={{ bgcolor: backgroundColor }}>
         <Toolbar>
           <LogoWrapper>
             <Link href="/">


### PR DESCRIPTION
Removes navbar hover/shadow, navbar by default has an elevation

![image](https://github.com/UWColonelKernel/uwwave/assets/53360069/b5ef7d40-6527-4927-b2ad-ae8098155b44)
